### PR TITLE
latest changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,10 @@ just_the_docs:
     content:
       name: Content
   footer_content: "&copy; 2025 DataCROP"
+  aux_links:
+    DataCROP GitHub:
+      url: https://github.com/datacrop
+      external: true
 
 plugins:
   - jekyll-default-layout

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,0 +1,4 @@
+<div style="margin-top: 1.5rem; padding: 0 2rem 2rem 2rem; text-align: left; font-size: 0.75rem; line-height: 1.5;">
+  <div style="font-weight: 600;">© 2025 DataCROP</div>
+</div>
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GitHub auxiliary link to the docs theme and introduces a custom footer include.
> 
> - **Theme configuration (`_config.yml`)**:
>   - Add `just_the_docs.aux_links` with "DataCROP GitHub" pointing to `https://github.com/datacrop` (marked `external: true`).
> - **UI/Includes**:
>   - Add custom footer markup in `_includes/nav_footer_custom.html` displaying "© 2025 DataCROP".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc139a32b8ceceadc6f78055dbcf57f704bd7baf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->