### PR TITLE
Update environment variable placeholders in Editor and Keycloak setup…

### DIFF
--- a/_content/Setup/editor/index.markdown
+++ b/_content/Setup/editor/index.markdown
@@ -20,13 +20,13 @@ After completing the setup, follow these steps to configure your environment var
 2. Update the file with the correct values for your infrastructure. Current values from `maze-workflow-management-editor/.env` are:
 
     ```plaintext
-    VITE_API_URL=http://167.235.128.77:9090
-    VITE_BACKEND_IP=167.235.128.77
-    VITE_AIRFLOW_IP=167.235.128.77
-    VITE_KEYCLOAK_URL=https://keycloak.modul4r.rid-intrasoft.eu/
-    VITE_KEYCLOAK_REALM=MODUL4R-Platform
-    VITE_KEYCLOAK_CLIENT_ID=modul4r-front
-    VITE_PROJECT_NAME=MODUL4R
+    VITE_API_URL=http://<WME_API_HOST>:9090
+    VITE_BACKEND_IP=<WME_API_HOST>
+    VITE_AIRFLOW_IP=<AIRFLOW_HOST>
+    VITE_KEYCLOAK_URL=https://<KEYCLOAK_HOST>/
+    VITE_KEYCLOAK_REALM=<KEYCLOAK_REALM>
+    VITE_KEYCLOAK_CLIENT_ID=<KEYCLOAK_CLIENT_ID>
+    VITE_PROJECT_NAME=<PROJECT_NAME>
     VITE_DEFAULT_PRIMARY_COLOR=#DA3333
     ```
 
@@ -82,7 +82,7 @@ Wait for the services to start, then run the following commands:
 
 #### Make Sure Everything Works
 
-1. Open a browser and navigate to the [web application](http://195.201.222.205:5173/MainPage/Warehouse).
+1. Open a browser and go to `http://<WME_UI_HOST>:5173/MainPage/Warehouse`.
 2. You will be redirected to the Keycloak authentication page. Enter the credentials provided by your organization.
 3. After successful authentication, you will be redirected to the main page of the workflow management engine, where you can begin creating and managing workflows.
 

--- a/_content/Setup/keycloak/index.markdown
+++ b/_content/Setup/keycloak/index.markdown
@@ -34,7 +34,7 @@ Before starting, ensure you have:
 1. **Create a Client**:
    - Navigate to **Clients** > **Create**.
    - Name the client (e.g., `frontend-client`).
-   - In the **Root URL**, **Admin URL**, and **Base URL**, replace the IP `195.201.222.205` with your own machine's IP:
+   - In the **Root URL**, **Admin URL**, and **Base URL**, use your own machine's IP (placeholder shown below):
      ```json
      "rootUrl": "http://YOUR_IP",
      "adminUrl": "http://YOUR_IP",


### PR DESCRIPTION
… instructions for improved clarity and security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces hardcoded IPs with placeholders and clarifies environment and URL configuration in Editor and Keycloak setup docs.
> 
> - **Docs**:
>   - **Editor setup (`_content/Setup/editor/index.markdown`)**:
>     - Replace concrete `.env` values with parameterized placeholders (`VITE_API_URL`, `VITE_BACKEND_IP`, `VITE_AIRFLOW_IP`, `VITE_KEYCLOAK_*`, `VITE_PROJECT_NAME`).
>     - Update UI access URL to `http://<WME_UI_HOST>:5173/MainPage/Warehouse`.
>   - **Keycloak setup (`_content/Setup/keycloak/index.markdown`)**:
>     - Remove hardcoded IP reference; instruct to use machine IP placeholders in Root/Admin/Base URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f1dc2cd33f219f2e657b08e54b7601da4bd31f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->