### PR TITLE
Enhance setup documentation by introducing a clear distinction betwee…

### DIFF
--- a/_content/Setup/airflow/index.markdown
+++ b/_content/Setup/airflow/index.markdown
@@ -1,12 +1,14 @@
 ---
 layout: page
-title: "2. Airflow Setup"
+title: "3. Airflow Setup"
 parent: Maize Setup
 permalink: /airflow/
-nav_order: 2
+nav_order: 3
 ---
 
 # DataCROP Maize Airflow Processing Engine Deployment
+
+Use this page when following the **manual per-repository setup**. If you use **Maize MVP**, this component is deployed by the MVP script; refer here only for customization or troubleshooting. See [Maize Setup](/Setup/) for the two setup options.
 
 This is a demo deployment instance for the **Maize DataCROP version**. It deploys the Airflow web server responsible for managing tasks within the **DataCROP Workflow Management Engine** infrastructure. The deployment consists of six containers.
 

--- a/_content/Setup/editor/index.markdown
+++ b/_content/Setup/editor/index.markdown
@@ -1,13 +1,15 @@
 ---
 layout: page
-title: 5. Workflow Editor Setup
+title: 6. Workflow Editor Setup
 parent: Maize Setup
 permalink: /editor/
-nav_order: 5
+nav_order: 6
 ---
 
 # DataCROP Maize Workflow Management Editor Deployment
 This is a demo deployment instance for the **Maize DataCROP version**. It deploys the **DataCROP Workflow Management Engine** web application for creating and managing workflows. The deployment consists of a single container.
+
+Use this page when following the **manual per-repository setup**. If you use **Maize MVP**, the editor is deployed by the MVP script; follow the initialization steps below once it is up. See [Maize Setup](/Setup/) for the two setup options.
 
 
 ### Prerequisites
@@ -79,6 +81,20 @@ Wait for the services to start, then run the following commands:
     maze-workflow-management-editor_wme-network   bridge    local
     ```
 
+
+### Post-deployment initialization (required)
+
+Perform this step after the UI is reachable (applies to both Maize MVP and manual setups):
+
+1. Log in through Keycloak.
+2. In the Workflow Editor UI, open **Settings**.
+3. Click **Initialize resources**.
+
+What this does:
+- Creates the base data models, workers, digital resources, and processor definitions needed for the application to function.
+- Imports any custom processors defined in `config/extra-processors.json` of the Model Repository (see [Model Repository Setup](/model-repo/)).
+
+Run this once per environment after deployments. Skipping it leaves the system uninitialized.
 
 #### Make Sure Everything Works
 

--- a/_content/Setup/index.markdown
+++ b/_content/Setup/index.markdown
@@ -7,11 +7,25 @@ nav_order: 2
 
 # DataCROP Maize Workflow Management Engine Deployment
 
-**This is a demo deployment instance for the Maize DataCROP version**
+You can set up the Maize stack in two ways:
 
+1. **Maize MVP (recommended)** — a single repository and script that brings up all Maize components together. Start here if you want the fastest path to a working demo.
+2. **Manual per-repository setup** — deploy each component yourself (Keycloak, Airflow, Worker, Model Repository, Workflow Editor) for fine-grained control.
 
+Use the MVP path if you want a quick, reproducible deployment. Choose the manual path if you need to customize each service, change infrastructure details, or operate components independently.
 
-In the sections below, you will find detailed instructions on setting up the various components of the DataCROP Maize system. 
+## Option 1: Maize MVP (single script)
 
-It is important to follow the deployment steps in the order presented to ensure proper integration. Start with the **DataCROP Maize Airflow Processing Engine**, which manages workflow tasks, followed by the **Processing Engine Worker**, responsible for executing these tasks. Afterward, deploy the **Model Repository**, which provides the infrastructure for managing models. Finally, set up the **Workflow Management Editor**, which allows you to create and manage workflows through the web application.
+Follow the instructions in the [Maize MVP Setup page](/mvp/) to configure the env files in each component folder of the MVP repository and run the one-shot setup script.
+
+## Option 2: Manual per-repository setup
+
+If you prefer to deploy each component separately, follow these pages in order:
+- [Keycloak Setup](/keycloak/)
+- [Airflow Setup](/airflow/)
+- [Worker Setup](/worker/)
+- [Model Repository Setup](/model-repo/)
+- [Workflow Editor Setup](/editor/)
+
+You can still reference the manual pages even when using the MVP path to understand what each service does and what each environment variable controls.
 

--- a/_content/Setup/keycloak/index.markdown
+++ b/_content/Setup/keycloak/index.markdown
@@ -1,12 +1,14 @@
 ---
 layout: page
-title: "1. Keycloak Setup"
+title: "2. Keycloak Setup"
 parent: Maize Setup
 permalink: /keycloak/
-nav_order: 1
+nav_order: 2
 ---
 
 # Keycloak Authentication Setup
+
+Use this page for the **manual per-repository setup**. That path assumes you configure Keycloak before deploying the other components. If you are using the **Maize MVP** path, Keycloak is provisioned/configured automatically; consult this page only if you need to customize it. See [Maize Setup](/Setup/) for the two setup options.
 
 This page will guide you through the steps required to set up Keycloak for the entire service. You will need to configure three Keycloak clients: one for the frontend, one for the backend, and one for the wrapper. Ensure you have administrator access to Keycloak to follow these steps.
 

--- a/_content/Setup/model-repo/index.markdown
+++ b/_content/Setup/model-repo/index.markdown
@@ -1,12 +1,14 @@
 ---
 layout: page
-title: 4. Model Repository Setup
+title: 5. Model Repository Setup
 parent: Maize Setup
 permalink: /model-repo/
-nav_order: 4
+nav_order: 5
 ---
 
 # DataCROP Maize Model Repository Deployment
+
+Use this page when following the **manual per-repository setup**. If you use **Maize MVP**, the model repository is deployed by the MVP script; refer here only for customization or troubleshooting. See [Maize Setup](/Setup/) for the two setup options.
 
 This is a demo deployment instance for the **Maize DataCROP version**. It deploys the **DataCROP Model Repository infrastructure**, consisting of two containers.
 
@@ -89,6 +91,29 @@ After completing the setup, follow these steps to configure your environment var
     ```
 
    Sensitive secrets are redacted above; ensure your `.env` retains the real values currently configured.
+
+### Optional: Predefining custom processors (before deploying the editor)
+
+- You can ship extra processor definitions for your project by adding a JSON file at `config/extra-processors.json` in the model repository project. The docker compose mounts it like:
+  - `./config/extra-processors.json:/app/config/extra-processors.json:ro`
+- The file contains an array of processor definitions. Example:
+
+  ```json
+  [
+    {
+      "name": "custom-logstash",
+      "type": "logstash",
+      "description": "Moves data from source A to sink B",
+      "image": "harbor.example.com/project/logstash-custom:1.0.0",
+      "parameters": {
+        "input": "digitalResourceIdA",
+        "output": "digitalResourceIdB"
+      }
+    }
+  ]
+  ```
+
+- Workflow: place your JSON file, deploy the Model Repository, deploy the Workflow Editor, then log in and click **Initialize resources** (see [Workflow Editor Setup](/editor/)). The initialization step loads this file and creates both the default and any extra processors you defined.
 
 Once these parameters are correctly set, you can proceed with the deployment
 

--- a/_content/Setup/mvp/index.markdown
+++ b/_content/Setup/mvp/index.markdown
@@ -1,0 +1,57 @@
+---
+layout: page
+title: "1. Maize MVP Setup"
+parent: Maize Setup
+permalink: /mvp/
+nav_order: 1
+---
+
+# Maize MVP (single-script deployment)
+
+Use the Maize MVP repository to bring up all Maize components with one script. This path is the fastest way to get a working demo; it provisions Keycloak automatically as part of the run.
+
+## Repository
+
+- Maize MVP repo: [https://github.com/datacrop/maize-mvp](https://github.com/datacrop/maize-mvp) (use your fork/URL if different).
+
+## Prerequisites
+
+- Docker installed on the host.
+- Network/ports open for Keycloak, Airflow, Worker, Model Repository, and Workflow Editor.
+
+## Configure environment variables
+
+1. Clone the MVP repository and `cd` into it.
+2. For each component subfolder (Keycloak, Airflow, Worker, Model Repository, Workflow Editor, etc.), open its `.env` or config file and adjust values for your environment (IP/hostnames, ports, credentials where applicable).
+3. Use the corresponding manual pages for variable meanings if needed:
+   - [Keycloak](/keycloak/), [Airflow](/airflow/), [Worker](/worker/), [Model Repository](/model-repo/), [Workflow Editor](/editor/)
+
+## Run the setup script
+
+1. In the repo root, run the provided setup script (typically `./scripts/setup.sh`; mark executable first if needed: `chmod +x scripts/setup.sh`).
+2. The script will run `docker compose up` for all components. Wait until containers are healthy.
+
+## Verify the deployment
+
+- Check containers:
+  - `docker ps --filter name=keycloak`
+  - `docker ps --filter name=airflow`
+  - `docker ps --filter name=worker`
+  - `docker ps --filter name=wme` (model repo)
+  - `docker ps --filter name=wme-ui` (workflow editor)
+- Open the Workflow Editor UI at `http://<WME_UI_HOST>:5173/MainPage/Warehouse` and confirm it loads.
+
+## Post-deployment (required)
+
+After the Workflow Editor UI is reachable:
+
+1. Log in via Keycloak.
+2. Go to **Settings** in the editor UI.
+3. Click **Initialize resources** (see [Workflow Editor Setup](/editor/) for details).
+4. This creates the base resources and any extra processors defined via the Model Repository. Skipping this leaves the system uninitialized.
+
+## Notes on Keycloak
+
+- In the MVP path, Keycloak is provisioned/configured automatically by the script; you do not need a pre-existing Keycloak instance.
+- If you need to customize Keycloak manually, refer to the [Keycloak Setup](/keycloak/) page.
+

--- a/_content/Setup/worker/index.markdown
+++ b/_content/Setup/worker/index.markdown
@@ -1,12 +1,14 @@
 ---
 layout: page
-title: 3. Worker Setup
+title: 4. Worker Setup
 parent: Maize Setup
 permalink: /worker/
-nav_order: 3
+nav_order: 4
 ---
 
 # DataCROP Maize Processing Engine Worker Deployment
+
+Use this page when following the **manual per-repository setup**. If you use **Maize MVP**, the worker is deployed by the MVP script; refer here only for customization or troubleshooting. See [Maize Setup](/Setup/) for the two setup options.
 
 This is a demo deployment instance for the **Maize DataCROP version**. It deploys a Worker responsible for handling tasks within the **DataCROP Workflow Management Engine**. The deployment consists of a single container.
 

--- a/_content/user-guide/overview/index.markdown
+++ b/_content/user-guide/overview/index.markdown
@@ -8,6 +8,8 @@ nav_order: 1
 
 # Getting Started
 
+Before using the Workflow Editor, choose a deployment path on the [Maize Setup](/Setup/) page: either the single-script Maize MVP approach or the manual per-repository setup.
+
 ## Accessing the Workflow Editor
 
 To access the Workflow Editor, you need to log in using **Keycloak**. You can authenticate in one of two ways:


### PR DESCRIPTION
…n the Maize MVP and manual per-repository deployment options. Update navigation order for setup pages and add post-deployment initialization steps for the Workflow Editor. Include guidance on customizing Keycloak and Model Repository configurations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a single-script MVP setup alongside manual setup, update nav order/titles, add required editor initialization, and document optional custom processors with cross-links across setup pages.
> 
> - **Setup docs restructuring**
>   - Add `/_content/Setup/mvp/index.markdown` describing the single-script Maize MVP deployment and verification.
>   - Update `/_content/Setup/index.markdown` to distinguish MVP vs manual paths and provide ordered links.
>   - Adjust titles and `nav_order` across setup pages (`/keycloak/`, `/airflow/`, `/worker/`, `/model-repo/`, `/editor/`).
> - **Workflow Editor** (`/_content/Setup/editor/index.markdown`)
>   - Add required post-deployment "Initialize resources" step and explain its effects.
>   - Clarify usage in MVP vs manual setups.
> - **Model Repository** (`/_content/Setup/model-repo/index.markdown`)
>   - Document optional `config/extra-processors.json` for shipping custom processors and how initialization imports them.
> - **Airflow/Worker/Keycloak pages**
>   - Add notes linking to MVP vs manual setup guidance and usage context.
> - **User Guide** (`/_content/user-guide/overview/index.markdown`)
>   - Add pointer to choose deployment path via `Maize Setup`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fce3c4a706937aada33e7bd758a13a0ed8df6609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->