### PR TITLE
Reorganize content

### DIFF
--- a/_content/Setup/index.markdown
+++ b/_content/Setup/index.markdown
@@ -16,11 +16,11 @@ Use the MVP path if you want a quick, reproducible deployment. Choose the manual
 
 ## Option 1: Maize MVP (single script)
 
-Follow the instructions in the [Maize MVP Setup page](/mvp/) to configure the env files in each component folder of the MVP repository and run the one-shot setup script.
+Follow the instructions in the [Maize MVP Setup page](/maize-mvp/) to configure the env files in each component folder of the MVP repository and run the one-shot setup script.
 
 ## Option 2: Manual per-repository setup
 
-If you prefer to deploy each component separately, follow these pages in order:
+If you prefer to deploy each component separately, go to the [Manual Setup landing page](/manual-setup/) and follow the component pages in order:
 - [Keycloak Setup](/keycloak/)
 - [Airflow Setup](/airflow/)
 - [Worker Setup](/worker/)

--- a/_content/Setup/maize-mvp/index.markdown
+++ b/_content/Setup/maize-mvp/index.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "1. Maize MVP Setup"
 parent: Maize Setup
-permalink: /mvp/
+permalink: /maize-mvp/
 nav_order: 1
 ---
 

--- a/_content/Setup/manual/airflow/index.markdown
+++ b/_content/Setup/manual/airflow/index.markdown
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: "3. Airflow Setup"
-parent: Maize Setup
+title: "2. Airflow Setup"
+parent: "2. Manual Setup"
 permalink: /airflow/
-nav_order: 3
+nav_order: 2
 ---
 
 # DataCROP Maize Airflow Processing Engine Deployment
@@ -123,3 +123,4 @@ Wait for the services to start, then run the following commands:
 Navigate to the source directory and run the following command.
 
     docker-compose down
+

--- a/_content/Setup/manual/editor/index.markdown
+++ b/_content/Setup/manual/editor/index.markdown
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: 6. Workflow Editor Setup
-parent: Maize Setup
+title: 5. Workflow Editor Setup
+parent: "2. Manual Setup"
 permalink: /editor/
-nav_order: 6
+nav_order: 5
 ---
 
 # DataCROP Maize Workflow Management Editor Deployment
@@ -108,3 +108,4 @@ Run this once per environment after deployments. Skipping it leaves the system u
 Navigate to the source directory and run the following command.
 
     docker-compose down
+

--- a/_content/Setup/manual/index.markdown
+++ b/_content/Setup/manual/index.markdown
@@ -1,0 +1,20 @@
+---
+layout: page
+title: "2. Manual Setup"
+parent: Maize Setup
+permalink: /manual-setup/
+nav_order: 2
+---
+
+# Manual per-repository setup
+
+Use this path if you want to deploy and customize each component separately. Follow the component pages in order:
+
+1. [Keycloak Setup](/keycloak/)
+2. [Airflow Setup](/airflow/)
+3. [Worker Setup](/worker/)
+4. [Model Repository Setup](/model-repo/)
+5. [Workflow Editor Setup](/editor/)
+
+You can still reference these pages even if you use the Maize MVP path, to understand variables and configuration details.
+

--- a/_content/Setup/manual/keycloak/index.markdown
+++ b/_content/Setup/manual/keycloak/index.markdown
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: "2. Keycloak Setup"
-parent: Maize Setup
+title: "1. Keycloak Setup"
+parent: "2. Manual Setup"
 permalink: /keycloak/
-nav_order: 2
+nav_order: 1
 ---
 
 # Keycloak Authentication Setup
@@ -123,7 +123,6 @@ Before starting, ensure you have:
 4. **Create a Wrapper-Dedicated Client Scope**:
    - Ensure there is a wrapper-dedicated client scope.
 
-
 ### 6. Configure Realm Roles
 
 1. **Verify Default Roles**:
@@ -161,8 +160,8 @@ Before starting, ensure you have:
    - Navigate to the **Realm Settings** section.
    - Adjust session duration settings and token settings according to the service's security requirements.
 
-
 ### Final Steps
 
 - After configuring all clients, ensure that each client is properly assigned its dedicated scope and roles.
 - You can verify the configuration by testing the login and authentication flows for the frontend, backend, and wrapper components.
+

--- a/_content/Setup/manual/model-repo/index.markdown
+++ b/_content/Setup/manual/model-repo/index.markdown
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: 5. Model Repository Setup
-parent: Maize Setup
+title: 4. Model Repository Setup
+parent: "2. Manual Setup"
 permalink: /model-repo/
-nav_order: 5
+nav_order: 4
 ---
 
 # DataCROP Maize Model Repository Deployment
@@ -170,3 +170,4 @@ docker-compose down
 Run the following command (**at your own risk**).
 
     docker-compose down --volumes --remove-orphans
+

--- a/_content/Setup/manual/worker/index.markdown
+++ b/_content/Setup/manual/worker/index.markdown
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: 4. Worker Setup
-parent: Maize Setup
+title: "3. Worker Setup"
+parent: "2. Manual Setup"
 permalink: /worker/
-nav_order: 4
+nav_order: 3
 ---
 
 # DataCROP Maize Processing Engine Worker Deployment
@@ -125,3 +125,4 @@ Wait for the services to start, then run the following commands:
 Navigate to the source directory and run the following command.
 
     docker-compose down
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorganizes setup docs by adding a manual setup landing page, updating page hierarchy/order, and changing the MVP path to `/maize-mvp/` with fixed references.
> 
> - **Docs IA reorg**:
>   - Add `Setup/manual/index.markdown` as a new landing page for manual installs at `/manual-setup/`.
>   - Reparent and renumber manual component pages under `"2. Manual Setup"` with updated `nav_order`:
>     - `keycloak` (1), `airflow` (2), `worker` (3), `model-repo` (4), `editor` (5).
>   - Change MVP page permalink to `/maize-mvp/` (`Setup/maize-mvp/index.markdown`).
>   - Update `Setup/index.markdown` links to point to `/maize-mvp/` and the new manual landing page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 693ab143227a29969bc3a18292d16268289d2b86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->