### PR TITLE
Update titles in Maize MVP and Manual Setup documentation for consist…

### DIFF
--- a/_content/Setup/maize-mvp/index.markdown
+++ b/_content/Setup/maize-mvp/index.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "1. Maize MVP Setup"
+title: "Maize MVP Setup"
 parent: Maize Setup
 permalink: /maize-mvp/
 nav_order: 1

--- a/_content/Setup/manual/index.markdown
+++ b/_content/Setup/manual/index.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "2. Manual Setup"
+title: "Manual Setup"
 parent: Maize Setup
 permalink: /manual-setup/
 nav_order: 2


### PR DESCRIPTION
…ency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes setup doc titles by removing numeric prefixes from the Maize MVP and Manual Setup pages.
> 
> - **Documentation**:
>   - Normalize front matter `title` by removing numeric prefixes in `_content/Setup/maize-mvp/index.markdown` and `_content/Setup/manual/index.markdown` for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4ad0013de50aea8866720c70526eb3afc4e5ecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->