### PR TITLE
Refactor docs regarding adding extra processors

### DIFF
--- a/_content/Setup/maize-mvp/index.markdown
+++ b/_content/Setup/maize-mvp/index.markdown
@@ -47,11 +47,11 @@ After the Workflow Editor UI is reachable:
 
 1. Log in via Keycloak.
 2. Go to **Settings** in the editor UI.
-3. Click **Initialize resources** (see [Workflow Editor Setup](/editor/) for details).
-4. This creates the base resources and any extra processors defined via the Model Repository. Skipping this leaves the system uninitialized.
+3. (Optional) Add predefined processor definitions by placing `extra-processors.json` in the Model Repository component's `config/` folder (copy from `extra-processors.example.json`) before running the MVP script / before initialization (see [Model Repository Setup](/model-repo/) for schema details).
+4. Click **Initialize resources** (see [Workflow Editor Setup](/editor/) for details).
+5. This creates the base resources and any extra processors defined via the Model Repository. Skipping this leaves the system uninitialized.
 
 ## Notes on Keycloak
 
 - In the MVP path, Keycloak is provisioned/configured automatically by the script; you do not need a pre-existing Keycloak instance.
 - If you need to customize Keycloak manually, refer to the [Keycloak Setup](/keycloak/) page.
-

--- a/_content/Setup/manual/editor/index.markdown
+++ b/_content/Setup/manual/editor/index.markdown
@@ -90,6 +90,8 @@ Perform this step after the UI is reachable (applies to both Maize MVP and manua
 2. In the Workflow Editor UI, open **Settings**.
 3. Click **Initialize resources**.
 
+If you want instance-specific predefined processors, configure `config/extra-processors.json` in the Model Repository before clicking Initialize resources; use `config/extra-processors.example.json` as a template.
+
 What this does:
 - Creates the base data models, workers, digital resources, and processor definitions needed for the application to function.
 - Imports any custom processors defined in `config/extra-processors.json` of the Model Repository (see [Model Repository Setup](/model-repo/)).
@@ -108,4 +110,3 @@ Run this once per environment after deployments. Skipping it leaves the system u
 Navigate to the source directory and run the following command.
 
     docker-compose down
-

--- a/_content/user-guide/overview/index.markdown
+++ b/_content/user-guide/overview/index.markdown
@@ -10,6 +10,8 @@ nav_order: 1
 
 Before using the Workflow Editor, choose a deployment path on the [Maize Setup](/Setup/) page: either the single-script Maize MVP approach or the manual per-repository setup.
 
+Available processors depend on your deployment; administrators can ship predefined processor definitions during deployment (see [Model Repository Setup](/model-repo/)).
+
 ## Accessing the Workflow Editor
 
 To access the Workflow Editor, you need to log in using **Keycloak**. You can authenticate in one of two ways:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies and expands docs for shipping predefined processor definitions via `config/extra-processors.json`, updating MVP, manual editor, model repo setup, and overview.
> 
> - **Docs – Predefined processors**
>   - **Model Repository Setup (`_content/Setup/manual/model-repo/index.markdown`)**:
>     - Rename/retitle section to “Predefining processor definitions (before initialization)”.
>     - Add step-by-step usage, mount path, and workflow for `config/extra-processors.json`.
>     - Document expected JSON schema and provide a full example.
>     - Add behavior notes (missing/invalid file handling, skip-on-duplicate by `name`).
>   - **Workflow Editor Setup (`_content/Setup/manual/editor/index.markdown`)**:
>     - Add note to configure `config/extra-processors.json` in the Model Repository before clicking **Initialize resources**.
>   - **Maize MVP Setup (`_content/Setup/maize-mvp/index.markdown`)**:
>     - Reorder post-deployment steps; insert optional step to add `extra-processors.json` before initialization.
>   - **User Guide Overview (`_content/user-guide/overview/index.markdown`)**:
>     - Note that available processors depend on deployment and can be predefined (link to Model Repository Setup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65e896e761d6b9529fabf6960bd54823ca48d47c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->